### PR TITLE
null type exception

### DIFF
--- a/DParser2/Resolver/DTypeToTypeDeclVisitor.cs
+++ b/DParser2/Resolver/DTypeToTypeDeclVisitor.cs
@@ -115,9 +115,10 @@ namespace D_Parser.Resolver
 
 			var ret = td;
 
-			while (def != (def = def.Parent as DNode) &&
+			while (def != null && def != (def = def.Parent as DNode) &&
 				def != null && !(def is DModule))
 			{
+				
 				td = td.InnerDeclaration = new IdentifierDeclaration(def.NameHash);
 			}
 


### PR DESCRIPTION
The loop was missing a null check, error caused:

```
{System.NullReferenceException: Object reference not set to an instance of an object.
   at D_Parser.Resolver.DTypeToTypeDeclVisitor.VisitDSymbol(DSymbol t) in e:\include\Mono-D\Parser\DParser2\Resolver\DTypeToTypeDeclVisitor.cs:line 118
   at D_Parser.Resolver.DTypeToTypeDeclVisitor.VisitMemberSymbol(MemberSymbol t) in e:\include\Mono-D\Parser\DParser2\Resolver\DTypeToTypeDeclVisitor.cs:line 178
   at D_Parser.Resolver.MemberSymbol.Accept[R](IResolvedTypeVisitor`1 vis) in e:\include\Mono-D\Parser\DParser2\Resolver\DType.cs:line 824
   at D_Parser.Resolver.StaticProperties.<.cctor>b__3a(AbstractType t, ResolutionContext ctxt) in e:\include\Mono-D\Parser\DParser2\Resolver\StaticProperties.cs:line 261
   at D_Parser.Resolver.StaticProperties.StaticPropertyInfo.GetPropertyType(AbstractType t, ResolutionContext ctxt) in e:\include\Mono-D\Parser\DParser2\Resolver\StaticProperties.cs:line 44
   at D_Parser.Resolver.StaticProperties.StaticPropertyInfo.GenerateRepresentativeNode(AbstractType t, ResolutionContext ctxt) in e:\include\Mono-D\Parser\DParser2\Resolver\StaticProperties.cs:line 54
   at D_Parser.Resolver.StaticProperties.<ListProperties>d__4a.MoveNext() in e:\include\Mono-D\Parser\DParser2\Resolver\StaticProperties.cs:line 403
   at D_Parser.Resolver.StaticProperties.ListProperties(ICompletionDataGenerator gen, ResolutionContext ctxt, MemberFilter vis, AbstractType t, Boolean isVariableInstance) in e:\include\Mono-D\Parser\DParser2\Resolver\StaticProperties.cs:line 366
   at D_Parser.Completion.Providers.MemberCompletionProvider.GenUfcsAndStaticProperties(AbstractType t) in e:\include\Mono-D\Parser\DParser2\Completion\Providers\MemberCompletionProvider.cs:line 58
   at D_Parser.Completion.Providers.MemberCompletionProvider.VisitTemplateIntermediateType(TemplateIntermediateType tr) in e:\include\Mono-D\Parser\DParser2\Completion\Providers\MemberCompletionProvider.cs:line 129
   at D_Parser.Completion.Providers.MemberCompletionProvider.VisitStructType(StructType t) in e:\include\Mono-D\Parser\DParser2\Completion\Providers\MemberCompletionProvider.cs:line 141
   at D_Parser.Resolver.StructType.Accept(IResolvedTypeVisitor vis) in e:\include\Mono-D\Parser\DParser2\Resolver\DType.cs:line 558
   at D_Parser.Completion.Providers.MemberCompletionProvider.VisitTemplateParameterSymbol(TemplateParameterSymbol tps) in e:\include\Mono-D\Parser\DParser2\Completion\Providers\MemberCompletionProvider.cs:line 193
   at D_Parser.Resolver.TemplateParameterSymbol.Accept(IResolvedTypeVisitor vis) in e:\include\Mono-D\Parser\DParser2\Resolver\DType.cs:line 876
   at D_Parser.Completion.Providers.MemberCompletionProvider.BuildCompletionDataInternal(IEditorData Editor, Char enteredChar) in e:\include\Mono-D\Parser\DParser2\Completion\Providers\MemberCompletionProvider.cs:line 47
   at D_Parser.Completion.Providers.AbstractCompletionProvider.BuildCompletionData(IEditorData Editor, Char enteredChar) in e:\include\Mono-D\Parser\DParser2\Completion\Providers\AbstractCompletionProvider.cs:line 39
   at D_Parser.Completion.CodeCompletion.GenerateCompletionData(IEditorData editor, ICompletionDataGenerator completionDataGen, Char triggerChar, Boolean alreadyCheckedCompletionContext) in e:\include\Mono-D\Parser\DParser2\Completion\CodeCompletion.cs:line 75
   at MonoDevelop.D.Completion.DCodeCompletionSupport.BuildCompletionData(Document EditorDocument, DModule SyntaxTree, CodeCompletionContext ctx, CompletionDataList l, Char triggerChar) in e:\include\Mono-D\MonoDevelop.DBinding\Completion\DCodeCompletionSupport.cs:line 30
   at MonoDevelop.D.DEditorCompletionExtension.HandleCodeCompletion(CodeCompletionContext completionContext, Char triggerChar, Int32& triggerWordLength) in e:\include\Mono-D\MonoDevelop.DBinding\Completion\EditorCompletionExtension.cs:line 78
   at MonoDevelop.Ide.Gui.Content.CompletionTextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.D.DEditorCompletionExtension.KeyPress(Key key, Char keyChar, ModifierType modifier) in e:\include\Mono-D\MonoDevelop.DBinding\Completion\EditorCompletionExtension.cs:line 216
   at MonoDevelop.Ide.Gui.Content.TextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.D.Formatting.Indentation.DTextEditorIndentation.KeyPress(Key key, Char keyChar, ModifierType modifier) in e:\include\Mono-D\MonoDevelop.DBinding\Formatting\Indentation\DTextEditorIndentation.cs:line 196
   at MonoDevelop.Ide.Gui.Content.TextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.Ide.Gui.Content.TextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.Ide.Gui.Content.TextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.Ide.Gui.Content.TextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.Debugger.ExceptionCaughtTextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.Ide.Gui.Content.TextEditorExtension.KeyPress(Key key, Char keyChar, ModifierType modifier)
   at MonoDevelop.SourceEditor.ExtensibleTextEditor.ExtensionKeyPress(Key key, UInt32 ch, ModifierType state)}
```
