### PR TITLE
fix tooltips emitting "static(double) x = 9,9" instead of "static double x = 9.9"

### DIFF
--- a/DParser2/Resolver/DTypeToTypeDeclVisitor.cs
+++ b/DParser2/Resolver/DTypeToTypeDeclVisitor.cs
@@ -23,9 +23,20 @@ namespace D_Parser.Resolver
 
 			var td = t.Accept(this);
 
-			if(t.HasModifiers){
-				foreach(byte modifier in t.Modifiers){
-					td = new MemberFunctionAttributeDecl (modifier) { InnerType = td };
+			if(t.HasModifiers)
+			{
+				foreach(byte modifier in t.Modifiers)
+				{
+					// only type modifier, no storage classes
+					switch (modifier)
+					{
+						case DTokens.Immutable:
+						case DTokens.Const:
+						case DTokens.InOut:
+						case DTokens.Shared:
+							td = new MemberFunctionAttributeDecl(modifier) { InnerType = td };
+							break;
+					}
 				}
 			}
 

--- a/DParser2/Resolver/ExpressionSemantics/ExpressionValues.cs
+++ b/DParser2/Resolver/ExpressionSemantics/ExpressionValues.cs
@@ -5,6 +5,7 @@ using D_Parser.Parser;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
+using System.Globalization;
 
 namespace D_Parser.Resolver.ExpressionSemantics
 {
@@ -60,6 +61,8 @@ namespace D_Parser.Resolver.ExpressionSemantics
 			return new PrimitiveValue(baseType, baseTypeMod);
 		}
 
+		static NumberFormatInfo nfi = System.Globalization.NumberFormatInfo.InvariantInfo;
+
 		public override string ToCode()
 		{
 			switch (BaseTypeToken)
@@ -74,7 +77,7 @@ namespace D_Parser.Resolver.ExpressionSemantics
 					return Char.ConvertFromUtf32((int)Value);
 			}
 
-			return Value.ToString() + (ImaginaryPart == 0 ? "" : ("+"+ImaginaryPart.ToString()+"i"));
+			return Value.ToString(nfi) + (ImaginaryPart == 0 ? "" : ("+"+ImaginaryPart.ToString()+"i"));
 		}
 
 		public override void Accept(ISymbolValueVisitor vis)


### PR DESCRIPTION
also makes some other tests more robust: normalize line endings, larger timeout