### PR TITLE
parse __vector and __parameters in IsExpression, evaluate __vector

### DIFF
--- a/DParser2/Dom/DDeclarations.cs
+++ b/DParser2/Dom/DDeclarations.cs
@@ -289,7 +289,8 @@ namespace D_Parser.Dom
 
 		public override string ToString(bool IncludesBase)
 		{
-			return (IncludesBase && InnerDeclaration != null ? (InnerDeclaration.ToString() + " ") : "") + "__vector(" + (Id != null ? Id.ToString() : "") + ")";
+			string basetype = Id != null ? Id.ToString() : IdDeclaration != null ? IdDeclaration.ToString() : "";
+			return (IncludesBase && InnerDeclaration != null ? (InnerDeclaration.ToString() + " ") : "") + "__vector(" + basetype + ")";
 		}
 
 		public override void Accept(TypeDeclarationVisitor vis) => vis.Visit(this);

--- a/DParser2/Parser/Implementations/DExpressionsParser.cs
+++ b/DParser2/Parser/Implementations/DExpressionsParser.cs
@@ -1099,6 +1099,8 @@ namespace D_Parser.Parser.Implementations
 						inout
 						shared
 							return
+							__vector
+							__parameters
 					*/
 
 					bool specialTest = false;
@@ -1118,6 +1120,8 @@ namespace D_Parser.Parser.Implementations
 							case DTokens.Immutable:
 							case DTokens.InOut:
 							case DTokens.Shared:
+							case DTokens.__vector:
+							case DTokens.__parameters:
 								specialTest = Peek(1).Kind == DTokens.CloseParenthesis || Lexer.CurrentPeekToken.Kind == DTokens.Comma;
 								break;
 							default:

--- a/DParser2/Parser/Tokens/DTokens.cs
+++ b/DParser2/Parser/Tokens/DTokens.cs
@@ -229,7 +229,9 @@ namespace D_Parser.Parser
 		public const string IncompleteId = "<Incomplete>";
 		public static readonly int IncompleteIdHash = IncompleteId.GetHashCode();
 
-		public const byte MaxToken = 185;
+		public const byte __parameters = 185;
+
+		public const byte MaxToken = 186;
 
 
 		static readonly Dictionary<byte, string> Keywords = new Dictionary<byte, string> {
@@ -237,6 +239,7 @@ namespace D_Parser.Parser
 			// {__thread, "__thread"},
 			{ __traits, "__traits" },
 			{ __vector, "__vector" },
+			{ __parameters, "__parameters" },
 
 			{ __LINE__, "__LINE__" },
 			{ __FILE__, "__FILE__" },

--- a/DParser2/Resolver/ExpressionSemantics/Evaluation.IsExpression.cs
+++ b/DParser2/Resolver/ExpressionSemantics/Evaluation.IsExpression.cs
@@ -214,6 +214,22 @@ namespace D_Parser.Resolver.ExpressionSemantics
 							res = retType_;
 					}
 					break;
+
+				case DTokens.__vector:
+					if (typeToCheck is DSymbol)
+					{
+						var vd = (typeToCheck as DSymbol).Definition.Type as VectorDeclaration;
+						if (vd != null)
+						{
+							r = true;
+							if (vd.IdDeclaration != null)
+								res = TypeDeclarationResolver.ResolveSingle(vd.IdDeclaration, ctxt);
+						}
+					}
+					break;
+
+				case DTokens.__parameters: // TODO
+					break;
 			}
 
 			return new Tuple<bool, AbstractType>(r, res);

--- a/Tests/ExpressionEvaluation/EvaluationTests.cs
+++ b/Tests/ExpressionEvaluation/EvaluationTests.cs
@@ -470,7 +470,37 @@ post;
 			Assert.That(ds.Base, Is.TypeOf(typeof(PrimitiveType)));
 			Assert.That(!(ds.Base as PrimitiveType).HasModifiers);
 		}
-		
+
+		[Test]
+		public void IsExpressionVector()
+		{
+			var ctxt = ResolutionTests.CreateCtxt("A", @"module A;
+alias int4 = int[4];
+alias float4 = __vector(float[4]);
+static if(is(float4 == __vector) { enum float4_isvector = true; }
+static if(is(int4 == __vector) {} else { enum int4_isvector = false; }
+");
+
+			IExpression x;
+			AbstractType t;
+			DSymbol ds;
+			ISymbolValue v;
+
+			x = DParser.ParseExpression("float4_isvector");
+			(x as IdentifierExpression).Location = new CodeLocation(2, 3);
+			t = ExpressionTypeEvaluation.EvaluateType(x, ctxt);
+			Assert.That(t, Is.TypeOf(typeof(MemberSymbol)));
+			v = Evaluation.EvaluateValue(x, ctxt);
+			Assert.That(v, Is.TypeOf(typeof(PrimitiveValue)));
+			Assert.That((v as PrimitiveValue).Value, Is.EqualTo(1m));
+
+			x = DParser.ParseExpression("int4_isvector");
+			(x as IdentifierExpression).Location = new CodeLocation(2, 3);
+			v = Evaluation.EvaluateValue(x, ctxt);
+			Assert.That(v, Is.TypeOf(typeof(PrimitiveValue)));
+			Assert.That((v as PrimitiveValue).Value, Is.EqualTo(0m));
+		}
+
 		[Test]
 		public void HashingTests()
 		{

--- a/Tests/ParseTests.cs
+++ b/Tests/ParseTests.cs
@@ -165,6 +165,16 @@ auto sourceCode = q{~this(){}}c;
 		}
 
 		[Test]
+		public void TestIsVector()
+		{
+			var mod = DParser.ParseString(@"alias T = int; static if (is(T == __vector) ) {}");
+			Assert.That(mod.ParseErrors.Count, Is.EqualTo(0));
+
+			var mod2 = DParser.ParseString(@"alias T = int; static if (is(T == __parameters) ) {}");
+			Assert.That(mod2.ParseErrors.Count, Is.EqualTo(0));
+		}
+
+		[Test]
 		public void TestAsmStorageClasses()
 		{
 			var mod = DParser.ParseString (@"void foo() {  asm @nogc nothrow { naked; } }");


### PR DESCRIPTION
See https://dlang.org/spec/expression.html#is_expression

also fixes displaying vector type.