### PR TITLE
avoid infinite loop for cyclic class base types

### DIFF
--- a/DParser2/Refactoring/TypeReferenceFinder.cs
+++ b/DParser2/Refactoring/TypeReferenceFinder.cs
@@ -571,9 +571,16 @@ namespace D_Parser.Refactoring
 					var kind = TypeReferenceKind.MemberVariable;
 					if (resolveTypes)
 					{
-						var type = LooseResolution.ResolveTypeLoosely(editorData, x, out _, false);
-						if(type != null)
-							kind = type.Accept(typeTypeDet);
+						try
+						{
+							var type = LooseResolution.ResolveTypeLoosely(editorData, x, out _, false);
+							if (type != null)
+								kind = type.Accept(typeTypeDet);
+						}
+						catch (Exception)
+						{
+							// avoid cancelling everything if it fails for some, e.g. System.NotImplementedException
+						}
 					}
 					AddResult(id, kind);
 				}

--- a/DParser2/Resolver/ASTScanner/AbstractVisitor.cs
+++ b/DParser2/Resolver/ASTScanner/AbstractVisitor.cs
@@ -202,9 +202,10 @@ to avoid op­er­a­tions which are for­bid­den at com­pile time.",
 			}*/
 
 			List<InterfaceType> interfaces = null;
-
-			while(udt!= null)
+			List<UserDefinedType> visitedUdts = new List<UserDefinedType> ();
+			while(udt!= null && !visitedUdts.Contains(udt))
 			{
+				visitedUdts.Add(udt);
 				parms.resolvedCurScope = udt;
 
 				scanChildren (udt.Definition as DBlockNode, parms);

--- a/DParser2/Resolver/ExpressionSemantics/Evaluation.Identifiers.cs
+++ b/DParser2/Resolver/ExpressionSemantics/Evaluation.Identifiers.cs
@@ -232,11 +232,11 @@ namespace D_Parser.Resolver.ExpressionSemantics
 			switch (id.Format)
 			{
 				case Parser.LiteralFormat.CharLiteral:
-					var tk = id.Subformat == LiteralSubformat.Utf32 ? DTokens.Dchar :
-						id.Subformat == LiteralSubformat.Utf16 ? DTokens.Wchar :
-						DTokens.Char;
-
-					return new PrimitiveValue(tk, Convert.ToDecimal((int)(char)id.Value));
+					if (id.Subformat == LiteralSubformat.Utf16)
+						return new PrimitiveValue(DTokens.Dchar, char.ConvertToUtf32(id.Value.ToString(), 0));
+					else if(id.Subformat == LiteralSubformat.Utf32)
+						return new PrimitiveValue(DTokens.Wchar, char.ConvertToUtf32(id.Value.ToString(), 0));
+					return new PrimitiveValue(DTokens.Char, Convert.ToDecimal((int)(char)id.Value));
 
 				case LiteralFormat.FloatingPoint | LiteralFormat.Scalar:
 					var im = id.Subformat.HasFlag(LiteralSubformat.Imaginary);

--- a/DParser2/Resolver/ExpressionSemantics/Evaluation.IsExpression.cs
+++ b/DParser2/Resolver/ExpressionSemantics/Evaluation.IsExpression.cs
@@ -84,7 +84,8 @@ namespace D_Parser.Resolver.ExpressionSemantics
 			if (retTrue)
 			{
 				foreach (var kv in tpl_params)
-					ctxt.CurrentContext.DeducedTemplateParameters[kv.Key] = kv.Value;
+					if (kv.Key != null && kv.Value != null)
+						ctxt.CurrentContext.DeducedTemplateParameters[kv.Key] = kv.Value;
 			}
 
 			return retTrue;
@@ -182,7 +183,7 @@ namespace D_Parser.Resolver.ExpressionSemantics
 					{
 						var udt = ClassInterfaceResolver.ResolveClassOrInterface(dc, ctxt, null, true) as ClassType;
 
-						if (r = udt.Base != null && ResultComparer.IsEqual(typeToCheck, udt.Base))
+						if (r = udt?.Base != null && ResultComparer.IsEqual(typeToCheck, udt.Base))
 						{
 							var l = new List<AbstractType>();
 							if (udt.Base != null)

--- a/DParser2/Resolver/ExpressionSemantics/ExpressionTypeEvaluation.cs
+++ b/DParser2/Resolver/ExpressionSemantics/ExpressionTypeEvaluation.cs
@@ -141,6 +141,9 @@ namespace D_Parser.Resolver.ExpressionSemantics
 		AbstractType TryPretendMethodExecution(IEnumerable<AbstractType> possibleOverloads, ISyntaxRegion typeBase = null, IEnumerable<AbstractType> args = null)
 		{
 			var allowedOverloads = new List<AbstractType>();
+			if (possibleOverloads == null)
+				return AmbiguousType.Get(allowedOverloads);
+
 			foreach (var overload in possibleOverloads)
 			{
 				if (DResolver.StripAliasedTypes(overload) is MemberSymbol ms)

--- a/DParser2/Resolver/StaticProperties.cs
+++ b/DParser2/Resolver/StaticProperties.cs
@@ -145,7 +145,7 @@ namespace D_Parser.Resolver
 			ValueGetter = 
 				(ctxt, state, v) =>
 				{
-					if (v is VariableValue vv)
+					if (state != null && v is VariableValue vv)
 						v = state.GetLocalValue(vv.Variable);
 					var av = v as ArrayValue;
 					return new PrimitiveValue(av?.Length ?? 0);
@@ -414,7 +414,7 @@ namespace D_Parser.Resolver
 				case TemplateParameterSymbol tps when (tps.Parameter is TemplateThisParameter parameter ?
 					parameter.FollowParameter : tps.Parameter) is TemplateTupleParameter:
 					return PropOwnerType.TypeTuple;
-				case MemberSymbol symbol when symbol.Definition.Parent is DClassLike ms && ms.ClassType == DTokens.Struct:
+				case MemberSymbol symbol when symbol.Definition?.Parent is DClassLike ms && ms.ClassType == DTokens.Struct:
 					return PropOwnerType.StructElement;
 				case MemberSymbol symbol:
 					return GetOwnerType(symbol.Base);
@@ -431,6 +431,9 @@ namespace D_Parser.Resolver
 
 		static void GetLookedUpType(ref AbstractType t)
 		{
+			while (t is MemberSymbol ms && ms.Base != null)
+				t = ms.Base;
+
 			while (t is AliasedType || t is PointerType)
 				t = (t as DerivedDataType).Base;
 

--- a/DParser2/Resolver/Templates/TemplateParameterDeductionVisitor.cs
+++ b/DParser2/Resolver/Templates/TemplateParameterDeductionVisitor.cs
@@ -223,8 +223,8 @@ namespace D_Parser.Resolver.Templates
 		{
 			var l = new List<ISemantic>();
 
-			if (parameter is DTuple)
-				foreach (var arg in (parameter as DTuple).Items)
+			if (parameter is DTuple tpl && tpl.Items != null)
+				foreach (var arg in tpl.Items)
 					if (arg is DTuple) // If a type tuple was given already, add its items instead of the tuple itself
 					{
 						var tt = arg as DTuple;

--- a/DParser2/Resolver/TypeResolution/SingleResolverVisitor.cs
+++ b/DParser2/Resolver/TypeResolution/SingleResolverVisitor.cs
@@ -104,7 +104,7 @@ namespace D_Parser.Resolver.TypeResolution
 		public AbstractType Visit (PointerDecl td)
 		{
 			filterTemplates = true;
-			var ptrBaseTypes = td.InnerDeclaration.Accept(this);
+			var ptrBaseTypes = td.InnerDeclaration?.Accept(this);
 
 			if (ptrBaseTypes != null)
 				ptrBaseTypes.NonStaticAccess = true;


### PR DESCRIPTION
fix nullptr exceptions

Ich hab' mir mal den ExaustiveCompletionTester auf TypeReferenceFinder umgebaut und auf ein paar Verzeichnisse losgelassen (phobos, druntime, visuald, dmd incl. tests). Dabei ist dparser u.a. an diesen Stellen gecrasht (meistens NullPointerException).
